### PR TITLE
Replace TextLog with Log widget

### DIFF
--- a/procure_pipeline_tui/main_tui.py
+++ b/procure_pipeline_tui/main_tui.py
@@ -41,7 +41,7 @@ from psycopg2.extras import RealDictCursor
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical, Container
 from textual.widgets import (
-    Header, Footer, Button, Input, Static, TextLog, DataTable, Label,
+    Header, Footer, Button, Input, Static, Log, DataTable, Label,
     Tabs, TabbedContent, TabPane,
 )
 from textual.reactive import reactive
@@ -227,13 +227,13 @@ class PipelineTUI(App):
         with Horizontal(id="main"):
             with Vertical(id="left"):
                 yield Static("[b]Проверки[/b]\n", id="chk_title")
-                yield TextLog(id="checks", highlight=True, wrap=True)
+                yield Log(id="checks", highlight=True)
             with Vertical(id="center"):
                 yield Static("[b]План[/b]", id="plan_title")
-                yield TextLog(id="plan_log", highlight=True, wrap=True)
+                yield Log(id="plan_log", highlight=True)
             with Vertical(id="right"):
                 yield Static("[b]LLM мета[/b]", id="meta_title")
-                yield TextLog(id="meta_log", highlight=True, wrap=True)
+                yield Log(id="meta_log", highlight=True)
         with Horizontal(id="controls"):
             yield Button("▶ Далее", id="next", disabled=True)
             yield Button("⛔ Прервать", id="abort", disabled=True)
@@ -242,13 +242,13 @@ class PipelineTUI(App):
 
     # helpers to write into logs
     def log_checks(self, text: str):
-        self.query_one(TextLog, id="checks").write(text)
+        self.query_one(Log, id="checks").write(text)
 
     def log_plan(self, text: str):
-        self.query_one(TextLog, id="plan_log").write(text)
+        self.query_one(Log, id="plan_log").write(text)
 
     def log_meta(self, text: str):
-        self.query_one(TextLog, id="meta_log").write(text)
+        self.query_one(Log, id="meta_log").write(text)
 
     def on_mount(self):
         # init session
@@ -291,9 +291,9 @@ class PipelineTUI(App):
         self.session_id = new_session_id()
         self.log_file = log_path(self.session_id)
         write_log(self.log_file, "session", {"session_id": self.session_id})
-        self.query_one(TextLog, id="checks").clear()
-        self.query_one(TextLog, id="plan_log").clear()
-        self.query_one(TextLog, id="meta_log").clear()
+        self.query_one(Log, id="checks").clear()
+        self.query_one(Log, id="plan_log").clear()
+        self.query_one(Log, id="meta_log").clear()
         self.plan = None
         self.llm_meta = None
         self.query_one(Button, id="next").disabled = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-textual
+textual>=0.61
 rich
 requests
 psycopg2-binary


### PR DESCRIPTION
## Summary
- Replace deprecated TextLog usage with the newer Log widget.
- Pin textual requirement to a version that provides the Log widget.

## Testing
- `python procure_pipeline_tui/main_tui.py` *(fails: terminal emulator crashed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c11aa5b9008321a2e8e8ab7a25fb42
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `TextLog` with `Log` widget in `main_tui.py` and update `textual` version in `requirements.txt`.
> 
>   - **Widgets**:
>     - Replace `TextLog` with `Log` in `compose()` and related methods in `main_tui.py`.
>     - Update `log_checks()`, `log_plan()`, and `log_meta()` to use `Log` instead of `TextLog`.
>   - **Dependencies**:
>     - Pin `textual` version to `>=0.61` in `requirements.txt` to ensure `Log` widget availability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2FTui-sgr&utm_source=github&utm_medium=referral)<sup> for 517c6f11313830dbd15a9b57a09a7893fd50b6be. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->