### PR TITLE
refactor: use CSS selectors in query_one

### DIFF
--- a/procure_pipeline_tui/main_tui.py
+++ b/procure_pipeline_tui/main_tui.py
@@ -242,13 +242,13 @@ class PipelineTUI(App):
 
     # helpers to write into logs
     def log_checks(self, text: str):
-        self.query_one(Log, id="checks").write(text)
+        self.query_one("#checks", Log).write(text)
 
     def log_plan(self, text: str):
-        self.query_one(Log, id="plan_log").write(text)
+        self.query_one("#plan_log", Log).write(text)
 
     def log_meta(self, text: str):
-        self.query_one(Log, id="meta_log").write(text)
+        self.query_one("#meta_log", Log).write(text)
 
     def on_mount(self):
         # init session
@@ -258,7 +258,7 @@ class PipelineTUI(App):
         # run checks
         self.run_checks()
         # focus input
-        self.query_one(Input, id="question").focus()
+        self.query_one("#question", Input).focus()
 
     def run_checks(self):
         self.log_checks("[b]DB:[/b] проверка соединения …")
@@ -291,19 +291,19 @@ class PipelineTUI(App):
         self.session_id = new_session_id()
         self.log_file = log_path(self.session_id)
         write_log(self.log_file, "session", {"session_id": self.session_id})
-        self.query_one(Log, id="checks").clear()
-        self.query_one(Log, id="plan_log").clear()
-        self.query_one(Log, id="meta_log").clear()
+        self.query_one("#checks", Log).clear()
+        self.query_one("#plan_log", Log).clear()
+        self.query_one("#meta_log", Log).clear()
         self.plan = None
         self.llm_meta = None
-        self.query_one(Button, id="next").disabled = True
-        self.query_one(Button, id="abort").disabled = True
+        self.query_one("#next", Button).disabled = True
+        self.query_one("#abort", Button).disabled = True
         self.run_checks()
-        self.query_one(Input, id="question").value = ""
-        self.query_one(Input, id="question").focus()
+        self.query_one("#question", Input).value = ""
+        self.query_one("#question", Input).focus()
 
     async def do_start(self):
-        q = self.query_one(Input, id="question").value.strip()
+        q = self.query_one("#question", Input).value.strip()
         if not q:
             self.bell()
             return
@@ -342,8 +342,8 @@ class PipelineTUI(App):
             self.log_meta(f"[b]response_chars:[/b] {meta.get('response_chars')}")
 
             # enable controls
-            self.query_one(Button, id="next").disabled = False
-            self.query_one(Button, id="abort").disabled = False
+            self.query_one("#next", Button).disabled = False
+            self.query_one("#abort", Button).disabled = False
         except Exception as e:
             write_log(self.log_file, "error", {"stage": "plan", "error": str(e)})
             self.log_plan(f"[red]Ошибка построения плана: {e}[/red]")


### PR DESCRIPTION
## Summary
- adopt new query_one selector syntax for logs, input, and button widgets

## Testing
- `timeout 5 python procure_pipeline_tui/main_tui.py`


------
https://chatgpt.com/codex/tasks/task_e_68c11c91f3d88321a44c2bd4fb35eb47
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `query_one` calls in `main_tui.py` to use CSS selectors for `Log`, `Input`, and `Button` widgets.
> 
>   - **Refactor**:
>     - Update `query_one` calls to use CSS selectors in `log_checks()`, `log_plan()`, `log_meta()`, `on_mount()`, `reset()`, and `do_start()` in `main_tui.py`.
>     - Affects `Log`, `Input`, and `Button` widgets by replacing `id` parameter with CSS selector syntax.
>   - **Testing**:
>     - Run `timeout 5 python procure_pipeline_tui/main_tui.py` to verify changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2FTui-sgr&utm_source=github&utm_medium=referral)<sup> for dd5e7e7f09d2746a93797ebb0473c19de1a66023. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->