### PR TITLE
feat: log model info before question

### DIFF
--- a/procure_pipeline_tui/main_console.py
+++ b/procure_pipeline_tui/main_console.py
@@ -200,12 +200,14 @@ class PipelineCLI:
 
     # main action
     def do_start(self) -> None:
+        if not self.db_ok or not self.llm_ok:
+            self.log_checks("Проверки не пройдены. Исправьте окружение и попробуйте снова.")
+            return
+        self.log_plan(f"Модель: {MODEL_NAME}")
+        self.log_plan(f"Опции: {{'temperature': 0.1, 'num_ctx': 8192}}")
         q = input("Введите точный вопрос: ").strip()
         if not q:
             self.log_plan("Вопрос пустой, ничего не делаем.")
-            return
-        if not self.db_ok or not self.llm_ok:
-            self.log_checks("Проверки не пройдены. Исправьте окружение и попробуйте снова.")
             return
         self.question = q
         write_log(self.log_file, "question", {"text": q})


### PR DESCRIPTION
## Summary
- Log model name and options before prompting for user question
- Avoid prompting when environment checks fail

## Testing
- `python -m py_compile procure_pipeline_tui/main_console.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c13c6675a083219aeb95fa8f4db50e