### PR TITLE
Add curses-based plan view

### DIFF
--- a/procure_pipeline_tui/main_console.py
+++ b/procure_pipeline_tui/main_console.py
@@ -13,10 +13,12 @@ import json
 import uuid
 import datetime as dt
 from typing import Any, Optional, Tuple
+import time
 
 import requests
 import psycopg2
 from dotenv import load_dotenv
+from plan_view import PlanView
 
 # ------------------------------
 # Config
@@ -237,6 +239,17 @@ class PipelineCLI:
             self.log_meta(f"eval_duration: {ed if ed is not None else 'n/a'}")
             self.log_meta(f"prompt_chars: {meta.get('prompt_chars')}")
             self.log_meta(f"response_chars: {meta.get('response_chars')}")
+
+            plan_view = PlanView(plan.get("steps", []))
+            for step in plan.get("steps", []):
+                sid = step.get("id")
+                plan_view.set_current(sid)
+                plan_view.refresh()
+                time.sleep(0.1)
+                plan_view.mark_done(sid)
+                plan_view.refresh()
+            plan_view.close()
+
             self.log_plan("Пока следующий шаг не реализован. Переходим к доработке Шага 1 (SQL).")
         except Exception as e:
             write_log(self.log_file, "error", {"stage": "plan", "error": str(e)})

--- a/procure_pipeline_tui/plan_view.py
+++ b/procure_pipeline_tui/plan_view.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Simple curses-based view for plan steps."""
+
+from typing import Dict, List, Optional, Set
+import curses
+
+
+class PlanView:
+    """Display plan steps and track current/completed state."""
+
+    def __init__(self, steps: List[Dict[str, str]]) -> None:
+        self.steps: List[Dict[str, str]] = steps
+        self.current_id: Optional[str] = None
+        self.done_ids: Set[str] = set()
+        self.screen = curses.initscr()
+        curses.noecho()
+        curses.cbreak()
+        self.screen.keypad(True)
+        self.refresh()
+
+    def _line(self, step: Dict[str, str]) -> str:
+        sid = step.get("id")
+        title = step.get("title", "")
+        prefix = "✅ " if sid in self.done_ids else "  "
+        return f"{prefix}{sid}. {title}"
+
+    def set_current(self, step_id: str) -> None:
+        self.current_id = step_id
+
+    def mark_done(self, step_id: str) -> None:
+        self.done_ids.add(step_id)
+
+    def refresh(self) -> None:
+        self.screen.clear()
+        for idx, step in enumerate(self.steps):
+            line = self._line(step)
+            if step.get("id") == self.current_id:
+                self.screen.addstr(idx, 0, line, curses.A_REVERSE)
+            else:
+                self.screen.addstr(idx, 0, line)
+        self.screen.refresh()
+
+    def close(self) -> None:
+        curses.nocbreak()
+        self.screen.keypad(False)
+        curses.echo()
+        curses.endwin()


### PR DESCRIPTION
## Summary
- Add PlanView class using curses to display plan steps with current and completed indicators
- Integrate PlanView into main_console to update and close after running through steps

## Testing
- `python -m py_compile procure_pipeline_tui/plan_view.py procure_pipeline_tui/main_console.py`

------
https://chatgpt.com/codex/tasks/task_e_68c13cee8a5083219b8ae8e5348d8751