### PR TITLE
feat: replace curses plan view with rich progress

### DIFF
--- a/procure_pipeline_tui/main_console.py
+++ b/procure_pipeline_tui/main_console.py
@@ -20,7 +20,7 @@ import psycopg2
 from dotenv import load_dotenv
 from rich.panel import Panel
 from rich.console import Console
-from plan_view import PlanView
+from plan_view import PlanProgress
 
 
 # Rich console for colored output
@@ -270,15 +270,13 @@ class PipelineCLI:
             self.log_meta(f"response_chars: {meta.get('response_chars')}")
 
             steps = plan["steps"]
-            plan_view = PlanView(steps)
+            progress = PlanProgress(steps)
             for step in steps:
                 sid = step.get("id")
-                plan_view.set_current(sid)
-                plan_view.refresh()
+                progress.set_current(sid)
                 time.sleep(0.1)
-                plan_view.mark_done(sid)
-                plan_view.refresh()
-            plan_view.close()
+                progress.mark_done(sid)
+            progress.close()
 
             self.log_plan("Пока следующий шаг не реализован. Переходим к доработке Шага 1 (SQL).")
         except Exception as e:

--- a/procure_pipeline_tui/plan_view.py
+++ b/procure_pipeline_tui/plan_view.py
@@ -1,48 +1,71 @@
 from __future__ import annotations
 
-"""Simple curses-based view for plan steps."""
+"""Rich-based progress display for plan steps."""
 
 from typing import Dict, List, Optional, Set
-import curses
+
+from rich.console import Group
+from rich.live import Live
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
+from rich.table import Table
 
 
-class PlanView:
-    """Display plan steps and track current/completed state."""
+class PlanProgress:
+    """Render plan steps with a progress bar using Rich."""
 
     def __init__(self, steps: List[Dict[str, str]]) -> None:
         self.steps: List[Dict[str, str]] = steps
         self.current_id: Optional[str] = None
         self.done_ids: Set[str] = set()
-        self.screen = curses.initscr()
-        curses.noecho()
-        curses.cbreak()
-        self.screen.keypad(True)
-        self.refresh()
 
-    def _line(self, step: Dict[str, str]) -> str:
-        sid = step.get("id")
-        title = step.get("title", "")
-        prefix = "✅ " if sid in self.done_ids else "  "
-        return f"{prefix}{sid}. {title}"
+        self._progress = Progress(
+            SpinnerColumn(),
+            BarColumn(bar_width=None),
+            TextColumn("{task.completed}/{task.total}"),
+            transient=True,
+        )
+        self._task_id = self._progress.add_task("steps", total=len(steps))
+
+        # Live needs explicit start/stop to ensure clean shutdown
+        self._live = Live(self._render(), refresh_per_second=4)
+        self._live.__enter__()
+
+    def _table(self) -> Table:
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("Title")
+        table.add_column("Status", style="magenta")
+
+        for step in self.steps:
+            sid = step.get("id", "")
+            title = step.get("title", "")
+            if sid in self.done_ids:
+                status = "✅ done"
+            elif sid == self.current_id:
+                status = "… running"
+            else:
+                status = "pending"
+            table.add_row(sid, title, status)
+        return table
+
+    def _render(self) -> Group:
+        return Group(self._table(), self._progress)
+
+    def refresh(self) -> None:
+        """Refresh the live display."""
+        self._live.update(self._render())
 
     def set_current(self, step_id: str) -> None:
         self.current_id = step_id
+        self.refresh()
 
     def mark_done(self, step_id: str) -> None:
-        self.done_ids.add(step_id)
-
-    def refresh(self) -> None:
-        self.screen.clear()
-        for idx, step in enumerate(self.steps):
-            line = self._line(step)
-            if step.get("id") == self.current_id:
-                self.screen.addstr(idx, 0, line, curses.A_REVERSE)
-            else:
-                self.screen.addstr(idx, 0, line)
-        self.screen.refresh()
+        if step_id not in self.done_ids:
+            self.done_ids.add(step_id)
+            self._progress.update(self._task_id, completed=len(self.done_ids))
+        self.refresh()
 
     def close(self) -> None:
-        curses.nocbreak()
-        self.screen.keypad(False)
-        curses.echo()
-        curses.endwin()
+        """Stop the live context."""
+        self._live.__exit__(None, None, None)
+


### PR DESCRIPTION
## Summary
- replace curses-based plan view with rich Live & Progress implementation
- wire main_console to use PlanProgress for step tracking

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement rich>=13.0)*
- `pytest`
- `python -m py_compile procure_pipeline_tui/plan_view.py procure_pipeline_tui/main_console.py`


------
https://chatgpt.com/codex/tasks/task_e_68c17ffed4048321b25510ae0e74ae57