### PR TITLE
feat: add dashboard ask input helper

### DIFF
--- a/procure_pipeline_tui/dashboard.py
+++ b/procure_pipeline_tui/dashboard.py
@@ -118,6 +118,10 @@ class Dashboard:
                 self.meta[k] = str(v)
         self._layout["right"].update(self._render_right_panel())
 
+    def ask(self, prompt: str) -> str:
+        """Request input from the user via the dashboard console."""
+        return self._live.console.input(prompt)
+
     # ------------------------------------------------------------------
     # Plan preview controls
     # ------------------------------------------------------------------

--- a/procure_pipeline_tui/main_console.py
+++ b/procure_pipeline_tui/main_console.py
@@ -229,7 +229,7 @@ class PipelineCLI:
         self.dashboard.update_status(
             "Schema/Plan Generation", "Опции: {'temperature': 0.1, 'num_ctx': 8192}"
         )
-        q = input("Введите точный вопрос: ").strip()
+        q = self.dashboard.ask("Введите точный вопрос: ").strip()
         if not q:
             self.dashboard.update_status(
                 "Schema/Plan Generation", "Вопрос пустой, ничего не делаем."


### PR DESCRIPTION
## Summary
- add `Dashboard.ask` to proxy user input through rich console
- use dashboard input helper in CLI start flow

## Testing
- `python procure_pipeline_tui/main_console.py` *(fails: connection to Postgres and Ollama refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c1852c8e608321b8849642b5aa043c