### PR TITLE
feat: add center activity panel

### DIFF
--- a/procure_pipeline_tui/dashboard.py
+++ b/procure_pipeline_tui/dashboard.py
@@ -29,6 +29,9 @@ class Dashboard:
         self.meta: Dict[str, str] = {}
         self.pipeline_steps: Dict[str, Dict[str, int | None]] = {}
 
+        # current activity for center panel
+        self.current_activity: str = ""
+
         # plan preview state
         self.plan_steps: List[Dict[str, Any]] = []  # {id, json}
         self.current_step: int = 0
@@ -131,7 +134,8 @@ class Dashboard:
         return Panel(body, title=tabs, border_style="magenta")
 
     def _render_center(self) -> Panel:
-        return Panel("", border_style="green")
+        """Render panel with current activity only."""
+        return Panel(self.current_activity, border_style="green")
 
     @staticmethod
     def _format_duration(ns: int) -> str:
@@ -151,6 +155,11 @@ class Dashboard:
     def update_status(self, block: str, message: str) -> None:
         self.statuses.setdefault(block, []).append(message)
         self._layout["pipeline_plan"].update(self._render_pipeline_plan())
+
+    def set_current_activity(self, message: str) -> None:
+        """Set current activity message in center panel."""
+        self.current_activity = message
+        self._layout["center"].update(self._render_center())
 
     def start_pipeline_step(self, step: str) -> None:
         """Mark the start time of a pipeline step."""


### PR DESCRIPTION
## Summary
- track current activity in dashboard and show in center panel
- expose `set_current_activity` to update the panel

## Testing
- `python -m py_compile procure_pipeline_tui/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1acfa46488321b92c0ec4dcebcaf5
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add center activity panel to `Dashboard` to track and display current activity.
> 
>   - **Behavior**:
>     - Track current activity in `Dashboard` class and display it in the center panel.
>     - Add `set_current_activity()` method to update the center panel with the current activity.
>   - **Rendering**:
>     - Modify `_render_center()` in `dashboard.py` to render the current activity.
>   - **Testing**:
>     - Ensure code compiles with `python -m py_compile procure_pipeline_tui/*.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hxrz11%2FTui-sgr&utm_source=github&utm_medium=referral)<sup> for f20086938c5c00d3ffbde4e3cad2ff132bd10634. You can [customize](https://app.ellipsis.dev/hxrz11/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->